### PR TITLE
fix(slides): rendering bug on ampersand

### DIFF
--- a/docs/ref/jz-content.md
+++ b/docs/ref/jz-content.md
@@ -55,8 +55,8 @@ hidden: true
 | 2018-12-05 | Pittsburgh CISSP Study Group                 | Software Development Security                                                  |
 | 2018-04-18 | Steel City InfoSec                           | The Use and Abuse of Blockchains                                               |
 | 2018-02-05 | InfraGard Pittsburgh                         | Steel City InfoSec                                                             |
-| 2017-12-00 | Unknown                                      | [Cutting through the buzz: ML & AI][2017-CTBSlides]                            |
-| 2017-10-20 | Three Rivers Information Security            | [Cutting through the buzz: ML & AI][2017-TRISS] ([Slides][2017-TRISSSlides])   |
+| 2017-12-00 | Unknown                                      | <a href="https://drive.google.com/uc?export=download&id=12Etkk6Q-sspTrSSEAOUWyEmuSP5BfJ35">Cutting through the buzz: ML & AI</a>                            |
+| 2017-10-20 | Three Rivers Information Security            | [Cutting through the buzz: ML & AI][2017-TRISS] (<a href="https://drive.google.com/uc?export=download&id=1N1C7M4_c7ccsU4lfKAt0Mi3UxlnM5mwb">Slides</a>)   |
 | 2017-09-13 | BroCon 2017                                  | Apache Metron                                                                  |
 | 2017-07-19 | NEOISF                                       | Security Data Analytics for the masses                                         |
 | 2017-03-15 | University of Pitt InfoSec Group             | Wireless Security                                                              |
@@ -119,8 +119,6 @@ You can also watch my recorded presentations by going to [this YouTube playlist]
 [2022-DevSecCon]: https://www.youtube.com/watch?v=Y1TGQWOmrTI "Simplifying IaC Security"
 [2022-CloudSecNext]: https://www.youtube.com/watch?v=jwqR_gtjSOc "IaC Security at Scale"
 [2017-TRISS]: https://www.youtube.com/watch?v=61qJnY9njgs "Cutting Through the Buzz: Machine Learning & Artificial Intelligence"
-[2017-TRISSSlides]: https://drive.google.com/uc?export=download&id=1N1C7M4_c7ccsU4lfKAt0Mi3UxlnM5mwb "Cutting Through the Buzz: Machine Learning & Artificial Intelligence Slides"
-[2017-CTBSlides]: https://drive.google.com/uc?export=download&id=12Etkk6Q-sspTrSSEAOUWyEmuSP5BfJ35 "Cutting Through the Buzz: Machine Learning & Artificial Intelligence Slides"
 [2017-SCIS]: https://www.youtube.com/watch?v=-\_ROZuYUNXY "Security Data Analysis for the masses"
 [2016-SCIS]: https://www.youtube.com/watch?v=4prUJI2Dm5Y "Proximity Attacks Intro"
 [2015-SCIS-PasswordCracking]: https://www.youtube.com/watch?v=QP7AEeeT-xQ "Password Cracking"


### PR DESCRIPTION
The link was rendering as `&amp;` not `&` and this approach fixes it (tested locally)

## Pull Request Checklist

- [X] e2e tests are passing OR the documentation was manually validated.
- [X] If there is an issue associated with your Pull Request, link the issue to the PR.