### PR TITLE
chore: add 2026 H2 talks and AAIF workshops

### DIFF
--- a/docs/ref/jz-content.md
+++ b/docs/ref/jz-content.md
@@ -9,6 +9,11 @@ hidden: true
 
 | Date       | Event                                        | Title                                                                          |
 | ---------- | -------------------------------------------- | ------------------------------------------------------------------------------ |
+| 2026-09-08 | [Alabama CSA][Alabama-CSA]                   | [AI Governance and Guardrails][2026-CSABirm]                                   |
+| 2026-09-03 | AAIF Workshop                                | Building Modern AI Agents (TODO: luma link not yet created)                    |
+| 2026-08-27 | AI@Work 10                                   | TODO: talk title pending                                                       |
+| 2026-08-27 | AAIF Workshop                                | [Building Modern AI Agents][2026-AAIF-Agents]                                  |
+| 2026-08-20 | SANS@Night                                   | Guardrails for AI Coding                                                       |
 | 2026-06-09 | SANS@Night                                   | Guardrails for AI Generated Code                                               |
 | 2026-02-19 | ISACA DC                                     | Guardrails for AI coding                                                       |
 | 2026-02-17 | AI Coding 2026                               | Live coding prototype and demo session                                         |
@@ -89,6 +94,7 @@ hidden: true
 
 You can also watch my recorded presentations by going to [this YouTube playlist](https://jonzeolla.com/youtube.html).
 
+[2026-AAIF-Agents]: https://luma.com/cpeus3f9 "Building Modern AI Agents"
 [CSN25]: https://www.youtube.com/watch?v=XaosRsgGSX8 "How I learned to stop worrying and love vibe coding: security edition"
 [2025-Devopsdays-dc]: https://devopsdays.org/events/2025-washington-dc/welcome/ "How I learned to stop worrying and love vibe coding: security edition"
 [2025-CloudSecNext]: https://www.sans.org/cyber-security-training-events/cloudsecnext-summit-2025/ "How I learned to stop worrying and love vibe coding: security edition"
@@ -101,6 +107,7 @@ You can also watch my recorded presentations by going to [this YouTube playlist]
 [PGHINFOSECDAY]: https://www.pghinfosecday.com/ "Pittsburgh InfoSec Day"
 [2024-gov-still-broken]: https://github.com/JonZeolla/monopreso/tree/main/presentations/2024-10-PGH-InfoSec-Day "Your Governance is (still) Broken"
 [Alabama-CSA]: https://circle.cloudsecurityalliance.org/alabama/home "Cloud Security Alliance Alabama Chapter"
+[2026-CSABirm]: https://www.meetup.com/cloud-security-alliance-alabama-chapter/events/316172772/ "AI Governance and Guardrails"
 [2024-CSABirm]: https://www.meetup.com/cloud-security-alliance-alabama-chapter/events/302397794/ "Automating Cloud Security with Jon Zeolla"
 [2024-CNSC]: https://youtu.be/HvLkkrNFiK8?si=pKXy-VvlDktl9ezU "Cloud Native GRC"
 [2024-CNSCSlides]: https://docs.google.com/presentation/d/167QYSLeDlz2pipln_V5kCVI2UWAIMRNpOQHBtIKikqg/edit?usp=drive_link "Cloud Native GRC Slides"

--- a/docs/ref/jz-content.md
+++ b/docs/ref/jz-content.md
@@ -11,7 +11,7 @@ hidden: true
 | ---------- | -------------------------------------------- | ------------------------------------------------------------------------------ |
 | 2026-09-08 | [Alabama CSA][Alabama-CSA]                   | [AI Governance and Guardrails][2026-CSABirm]                                   |
 | 2026-09-03 | AAIF Workshop                                | Building Modern AI Agents (TODO: luma link not yet created)                    |
-| 2026-08-27 | AI@Work 10                                   | TODO: talk title pending                                                       |
+| 2026-08-27 | AI@Work 10                                   | Coding Agent Loops                                                             |
 | 2026-08-27 | AAIF Workshop                                | [Building Modern AI Agents][2026-AAIF-Agents]                                  |
 | 2026-08-20 | SANS@Night                                   | Guardrails for AI Coding                                                       |
 | 2026-06-09 | SANS@Night                                   | Guardrails for AI Generated Code                                               |

--- a/docs/ref/jz-content.md
+++ b/docs/ref/jz-content.md
@@ -10,7 +10,7 @@ hidden: true
 | Date       | Event                                        | Title                                                                          |
 | ---------- | -------------------------------------------- | ------------------------------------------------------------------------------ |
 | 2026-09-08 | [Alabama CSA][Alabama-CSA]                   | [AI Governance and Guardrails][2026-CSABirm]                                   |
-| 2026-09-03 | AAIF Workshop                                | Building Modern AI Agents (TODO: luma link not yet created)                    |
+| 2026-09-03 | AAIF Workshop                                | [Building Modern AI Agents][2026-AAIF-Agents-0903]                             |
 | 2026-08-27 | AI@Work 10                                   | Coding Agent Loops                                                             |
 | 2026-08-27 | AAIF Workshop                                | [Building Modern AI Agents][2026-AAIF-Agents]                                  |
 | 2026-08-20 | SANS@Night                                   | Guardrails for AI Coding                                                       |
@@ -25,7 +25,7 @@ hidden: true
 | 2025-09-25 | SANS Network Security 2025                   | AI Tools for Security Professionals                                            |
 | 2025-09-19 | [BSides Columbus][2025-BSidesCol]            | How I learned to stop worrying and love vibe coding: security edition          |
 | 2025-09-18 | [DevOpsDays DC][2025-Devopsdays-dc]          | How I learned to stop worrying and love vibe coding: security edition          |
-| 2025-07-11 | [BSides Pittsburgh][2025-BSidesPGH]          | How I learned to stop worrying and love vibe coding: security edition          |
+| 2025-07-11 | [BSides Pittsburgh][2025-BSidesPGH]          | [How I learned to stop worrying and love vibe coding: security edition][BSPGH25] |
 | 2025-05-28 | [CSA Pittsburgh][2025-CSAPgh]                | [Vibe coding safety course][2025-CSA-coding-assist]                            |
 | 2025-02-18 | [ISSA Pittsburgh][2025-ISSA]                 | [Container Security][2025-container-security]                                  |
 | 2024-10-28 | [Pittsburgh InfoSec Day 2024][PGHINFOSECDAY] | [Your Governance Is (Still) Broken][2024-gov-still-broken]                     |
@@ -95,11 +95,13 @@ hidden: true
 You can also watch my recorded presentations by going to [this YouTube playlist](https://jonzeolla.com/youtube.html).
 
 [2026-AAIF-Agents]: https://luma.com/cpeus3f9 "Building Modern AI Agents"
+[2026-AAIF-Agents-0903]: https://luma.com/eob7xzdb "Building Modern AI Agents"
 [CSN25]: https://www.youtube.com/watch?v=XaosRsgGSX8 "How I learned to stop worrying and love vibe coding: security edition"
 [2025-Devopsdays-dc]: https://devopsdays.org/events/2025-washington-dc/welcome/ "How I learned to stop worrying and love vibe coding: security edition"
 [2025-CloudSecNext]: https://www.sans.org/cyber-security-training-events/cloudsecnext-summit-2025/ "How I learned to stop worrying and love vibe coding: security edition"
 [2025-BSidesCol]: https://www.bsidescolumbus.com/ "How I learned to stop worrying and love vibe coding: security edition"
 [2025-BSidesPGH]: https://bsidespgh.com/2025 "How I learned to stop worrying and love vibe coding: security edition"
+[BSPGH25]: https://youtu.be/oPhGKduOrKM "How I learned to stop worrying and love vibe coding: security edition"
 [2025-CSAPgh]: https://events.humanitix.com/csa-pittsburgh-chapter-in-person-meetup "Vibe coding safety course"
 [2025-CSA-coding-assist]: https://youtu.be/6s6K2zelYQo "Vibe coding safety course"
 [2025-container-security]: https://github.com/JonZeolla/monopreso/tree/main/presentations/2025-02-ISSA-Pittsburgh "Container Security"


### PR DESCRIPTION
Adds recent and upcoming speaking engagements to Event Presentations in `docs/ref/jz-content.md`:

| Date | Event | Title |
|---|---|---|
| 2026-09-08 | Alabama CSA | AI Governance and Guardrails |
| 2026-09-03 | AAIF Workshop | Building Modern AI Agents |
| 2026-08-27 | AI@Work 10 | _title pending_ |
| 2026-08-27 | AAIF Workshop | Building Modern AI Agents |
| 2026-08-20 | SANS@Night | Guardrails for AI Coding |

Two placeholders remain, marked with TODOs in the table:
- AI@Work 10 talk title
- luma link for the 2026-09-03 AAIF workshop (event not yet created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYn9r5bYo41g2FwadURpJw